### PR TITLE
Alternate subtitiutions

### DIFF
--- a/src/mmmvi.py
+++ b/src/mmmvi.py
@@ -619,7 +619,7 @@ def format_positions_mutations(positions_mutations):
         # insertion
         if None in p:
             species_positions.append(p[0])
-            species_mutations.append(m)
+            species_mutations.append(tuple("del" if x is None else x for x in m))
 
         else:
             species_positions.extend(p)


### PR DESCRIPTION
- Allow multiple substitutions in the same position and the same VOC
    - e.g. `C23604A` and `C23604G`

- Refactor codebase
    - Reporting has been greatly simplified without changing output